### PR TITLE
Also find constants that have numbers as values

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -65,6 +65,8 @@ class Parser
                     }
                     break;
                 case T_CONSTANT_ENCAPSED_STRING:
+                case T_LNUMBER:
+                case T_DNUMBER:
                     if ($isConst && $isValue) {
                         $constants[$constName] = new Constant($constName, trim($tokenValue, '"\''), $doc);
                     }

--- a/tests/ConstantParserTest.php
+++ b/tests/ConstantParserTest.php
@@ -3,11 +3,12 @@ namespace tests;
 
 require_once __DIR__ . '/stubs/ConstantClassStub1.php';
 
+use PHPUnit\Framework\TestCase;
 use rg\phpConstantDocComment\Constant;
 use rg\phpConstantDocComment\Parser;
 use tests\stubs\ConstantClassStub1;
 
-class ConstantParserTest extends \PHPUnit_Framework_TestCase
+class ConstantParserTest extends TestCase
 {
     public function testParser()
     {
@@ -41,6 +42,14 @@ class ConstantParserTest extends \PHPUnit_Framework_TestCase
      * @annotations\test1Annotation("value1")
      * @annotations\test2Annotation("value2")
      */');
+
+     $this->assertConstantValues(
+            $constants['TEST_CONSTANT4'],
+            'TEST_CONSTANT4',
+            4,
+            '/**
+    * @annotations\test4Annotation
+    */');
 
     }
 

--- a/tests/stubs/ConstantClassStub1.php
+++ b/tests/stubs/ConstantClassStub1.php
@@ -30,4 +30,9 @@ class ConstantClassStub1 {
      * @annotations\test2Annotation("value2")
      */
     const TEST_CONSTANT3 = '3';
+
+    /**
+    * @annotations\test4Annotation
+    */
+    const TEST_CONSTANT4 = 4;
 }


### PR DESCRIPTION
If a defined constant has a number instead of a string as value it wouldn't appear in the list of constants