### PR TITLE
Reset doc when constant is matched

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -62,6 +62,7 @@ class Parser
                         $constValue = null;
                         $isConst = false;
                         $isValue = false;
+                        $doc = null;
                     }
                     break;
                 case T_CONSTANT_ENCAPSED_STRING:
@@ -74,6 +75,7 @@ class Parser
                     $constValue = null;
                     $isConst = false;
                     $isValue = false;
+                    $doc = null;
                     break;
                 // all other tokens reset the parser
                 default:
@@ -81,6 +83,7 @@ class Parser
                     $constValue = null;
                     $isConst = false;
                     $isValue = false;
+                    $doc = null;
                     break;
             }
         }

--- a/tests/ConstantParserTest.php
+++ b/tests/ConstantParserTest.php
@@ -52,7 +52,19 @@ class ConstantParserTest extends TestCase
     */');
 
     }
+    
+    public function testEmptyDoc()
+    {
+        $class = new \ReflectionClass(ConstantClassStub1::class);
+        $reader = new Parser;
 
+        $constants = $reader->getClassConstants($class);
+        $this->assertConstantValues(
+            $constants['TEST_CONSTANT5'],
+            'TEST_CONSTANT5',
+            5,
+            '');
+    }
     private function assertConstantValues(Constant $constant, $name, $value, $docComment)
     {
         $this->assertEquals($constant->getName(), $name);

--- a/tests/stubs/ConstantClassStub1.php
+++ b/tests/stubs/ConstantClassStub1.php
@@ -35,4 +35,7 @@ class ConstantClassStub1 {
     * @annotations\test4Annotation
     */
     const TEST_CONSTANT4 = 4;
+ 
+    const TEST_CONSTANT5 = 5;
+
 }


### PR DESCRIPTION
Hi,
thanks for sharing your work & apllying the other PR so quickly. Here is another one:
If one const doesn't have a comment, the prevoious one would be taken.
